### PR TITLE
feat: Add random emotion option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /__pycache__/
 /.vs/
 /emoji_png/
+/.venv/


### PR DESCRIPTION
原本的逻辑是：
选中一个表情，并固定一次，此后重新回到随机表情。我认为这不符合正常习惯，而且用户也很难看出来这个逻辑，他们大概率会认为这个有bug只能随机（
所以添加了个专门的随机表情按钮，并把逻辑改成了人类（还有魔女）会接受的。但是在切换角色后这个随机表情不能正常选中。
这个bug在 #38 有提及
如果那个能修复的话，这个大概也是没问题的。

另外很想吐槽的就是，我去用了下main.py发现不能用，路径什么的全错了自己修了半天看到 #27 原来提到过了，马上进行了一堆更改的放弃
